### PR TITLE
Add custom IAM role for GKE firewall resources

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,4 +35,4 @@ jobs:
       terraform_plan_secret_args: >-
         -var=billing_account=${{ secrets.BILLING_ACCOUNT }}
         -var=customer_id=${{ secrets.CUSTOMER_ID }}
-        -var=organization_id=${{ secrets.ORGANIZATION_ID }} 
+        -var=organization_id=${{ secrets.ORGANIZATION_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -12,7 +12,7 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.4
+    rev: v1.83.5
     hooks:
       - id: terraform_fmt
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,10 @@
 # <img align="left" width="45" height="45" src="https://github.com/osinfra-io/terraform-google-cloud-sql/assets/1610100/ef899efa-b2ce-4c31-83cf-debefadd481d"> Security Policy
 
-Open Source Infrastructure (as Code) exposes identifying information that would not be exposed in a traditional 
+Open Source Infrastructure (as Code) exposes identifying information that would not be exposed in a traditional
 private organization to share knowledge and best practices. This is a net positive for
-the community, but it does come with some risks. 
+the community, but it does come with some risks.
 
 ## Reporting a Vulnerability
 
-Privately discuss, fix, and publish information about security vulnerabilities in this repository by drafting a new 
+Privately discuss, fix, and publish information about security vulnerabilities in this repository by drafting a new
 [security advisory](https://github.com/osinfra-io/google-cloud-hierarchy/security/advisories/new).

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.4.0 |
 
 ## Modules
 
@@ -29,6 +29,7 @@ No modules.
 | [google_folder.service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder) | resource |
 | [google_folder.team](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder) | resource |
 | [google_folder_iam_policy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_policy) | resource |
+| [google_organization_iam_custom_role.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_iam_policy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
 
@@ -37,11 +38,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | The alphanumeric ID of the billing account this project belongs to | `string` | n/a | yes |
+| <a name="input_billing_project"></a> [billing\_project](#input\_billing\_project) | The quota project to send in `user_project_override`, used for all requests sent from the provider. If set on a resource that supports sending the resource project, this value will supersede the resource project. This field is ignored if `user_project_override` is set to false or unset | `string` | n/a | yes |
 | <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | The unique customer ID assigned to you when you signed up for Google Workspace or Cloud Identity. You can look up this ID in your Admin console | `string` | n/a | yes |
 | <a name="input_folder_iam_policies"></a> [folder\_iam\_policies](#input\_folder\_iam\_policies) | A map of authoritative IAM policies for the folder, replaces any existing policy already attached | <pre>map(object({<br>    team        = string<br>    service     = string<br>    environment = string<br>    bindings = list(object({<br>      members = list(string)<br>      role    = string<br>    }))<br>  }))</pre> | n/a | yes |
 | <a name="input_folder_services"></a> [folder\_services](#input\_folder\_services) | A map of folder services to create | <pre>map(object({<br>    display_name          = string<br>    environments          = list(string)<br>    monthly_budget_amount = optional(number, 10)<br>    parent                = string<br>  }))</pre> | n/a | yes |
 | <a name="input_folder_teams"></a> [folder\_teams](#input\_folder\_teams) | A map of folder teams to create | <pre>map(object({<br>    display_name = string<br>  }))</pre> | n/a | yes |
 | <a name="input_identity_groups"></a> [identity\_groups](#input\_identity\_groups) | A map of identity groups to create | <pre>map(object({<br>    description  = string<br>    display_name = string<br>    managers     = list(string)<br>    members      = list(string)<br>    owners       = list(string)<br>    roles        = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_organization_custom_iam_roles"></a> [organization\_custom\_iam\_roles](#input\_organization\_custom\_iam\_roles) | A map of organization custom IAM roles to create | <pre>map(object({<br>    description = optional(string, null)<br>    permissions = list(string)<br>    role_id     = string<br>    title       = string<br>  }))</pre> | n/a | yes |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The organization ID to create the hierarchy under | `string` | n/a | yes |
 | <a name="input_organization_monthly_budget_amount"></a> [organization\_monthly\_budget\_amount](#input\_organization\_monthly\_budget\_amount) | The organization monthly budget amount in USD | `number` | `50` | no |
 | <a name="input_primary_domain"></a> [primary\_domain](#input\_primary\_domain) | The main domain associated with your Google Workspace account. By default, your users get a username at this domain | `string` | `"osinfra.io"` | no |

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -530,3 +530,22 @@ identity_groups = {
     roles        = []
   }
 }
+
+organization_custom_iam_roles = {
+  host-gke-firewall-management = {
+    description = "Allows for a GKE cluster in a service project to create and manage the firewall resources in your host project"
+    permissions = [
+      "compute.firewalls.create",
+      "compute.firewalls.delete",
+      "compute.firewalls.get",
+      "compute.firewalls.list",
+      "compute.firewalls.update",
+      "compute.networks.updatePolicy"
+    ]
+
+    # Align with Google's role naming convention
+
+    role_id = "kubernetes.hostFirewallManagement"
+    title   = "Host Kubernetes Firewall Management"
+  }
+}

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -10,10 +10,10 @@ variable "billing_account" {
 # The google_cloud_identity_group resource requires this if you are using User ADCs (Application Default Credentials).
 # This is only needed during bootstrapping.
 
-# variable "billing_project" {
-#   description = "The quota project to send in `user_project_override`, used for all requests sent from the provider. If set on a resource that supports sending the resource project, this value will supersede the resource project. This field is ignored if `user_project_override` is set to false or unset"
-#   type        = string
-# }
+variable "billing_project" {
+  description = "The quota project to send in `user_project_override`, used for all requests sent from the provider. If set on a resource that supports sending the resource project, this value will supersede the resource project. This field is ignored if `user_project_override` is set to false or unset"
+  type        = string
+}
 
 variable "customer_id" {
   description = "The unique customer ID assigned to you when you signed up for Google Workspace or Cloud Identity. You can look up this ID in your Admin console"
@@ -60,6 +60,16 @@ variable "identity_groups" {
     members      = list(string)
     owners       = list(string)
     roles        = list(string)
+  }))
+}
+
+variable "organization_custom_iam_roles" {
+  description = "A map of organization custom IAM roles to create"
+  type = map(object({
+    description = optional(string, null)
+    permissions = list(string)
+    role_id     = string
+    title       = string
   }))
 }
 


### PR DESCRIPTION
This pull request adds a custom IAM role for GKE firewall resources in the host project. This role allows a GKE cluster in a service project to create and manage the firewall resources in the host project. The role aligns with Google's role naming convention and includes the necessary permissions. 

Fixes #159