### PR TITLE
Add backend service accounts

### DIFF
--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -523,6 +523,7 @@ identity_groups = {
       "plt-lz-backend-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com",
       "plt-lz-hierarchy-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com",
       "plt-lz-identity-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com",
+      "plt-k8s-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com",
       "plt-lz-networking-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com",
       "plt-lz-testing-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com"
     ]
@@ -542,6 +543,7 @@ identity_groups = {
       "plt-lz-backend-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com",
       "plt-lz-hierarchy-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com",
       "plt-lz-identity-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com",
+      "plt-k8s-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com",
       "plt-lz-networking-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com",
       "plt-lz-testing-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com"
     ]
@@ -561,6 +563,7 @@ identity_groups = {
       "plt-lz-backend-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com",
       "plt-lz-hierarchy-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com",
       "plt-lz-identity-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com",
+      "plt-k8s-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com",
       "plt-lz-networking-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com",
       "plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
     ]


### PR DESCRIPTION
This pull request adds backend service accounts to the project. These service accounts are necessary for various backend functionalities and integrations. The new service accounts include plt-k8s-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com, plt-k8s-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com, and plt-k8s-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com. 