### PR TITLE
Add compute.xpnAdmin role to terraform-backend groups

### DIFF
--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -25,10 +25,10 @@ terraform {
 
 # This is only needed during bootstrapping.
 
-# provider "google" {
-#   billing_project       = var.billing_project
-#   user_project_override = true
-# }
+provider "google" {
+  billing_project       = var.billing_project
+  user_project_override = true
+}
 
 # IAM Policy Data Source
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -68,6 +68,12 @@ folder_iam_policies = {
       },
       {
         members = [
+          "group:terraform-backend-sb@osinfra.io"
+        ]
+        role = "roles/compute.xpnAdmin"
+      },
+      {
+        members = [
           "serviceAccount:plt-k8s-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
         ]
         role = "roles/resourcemanager.projectCreator"
@@ -87,6 +93,12 @@ folder_iam_policies = {
       },
       {
         members = [
+          "group:terraform-backend-nonprod@osinfra.io"
+        ]
+        role = "roles/compute.xpnAdmin"
+      },
+      {
+        members = [
           "serviceAccount:plt-k8s-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com"
         ]
         role = "roles/resourcemanager.projectCreator"
@@ -103,6 +115,12 @@ folder_iam_policies = {
           "group:terraform-backend-prod@osinfra.io"
         ]
         role = "roles/resourcemanager.folderIamAdmin"
+      },
+      {
+        members = [
+          "group:terraform-backend-prod@osinfra.io"
+        ]
+        role = "roles/compute.xpnAdmin"
       },
       {
         members = [

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -10,10 +10,10 @@ variable "billing_account" {
 # The google_cloud_identity_group resource requires this if you are using User ADCs (Application Default Credentials).
 # This is only needed during bootstrapping.
 
-# variable "billing_project" {
-#   description = "The quota project to send in `user_project_override`, used for all requests sent from the provider. If set on a resource that supports sending the resource project, this value will supersede the resource project. This field is ignored if `user_project_override` is set to false or unset"
-#   type        = string
-# }
+variable "billing_project" {
+  description = "The quota project to send in `user_project_override`, used for all requests sent from the provider. If set on a resource that supports sending the resource project, this value will supersede the resource project. This field is ignored if `user_project_override` is set to false or unset"
+  type        = string
+}
 
 variable "customer_id" {
   description = "The unique customer ID assigned to you when you signed up for Google Workspace or Cloud Identity. You can look up this ID in your Admin console"


### PR DESCRIPTION
This pull request adds the `compute.xpnAdmin` role to the `terraform-backend` groups in order to grant them the necessary permissions for cross-project networking. This change ensures that the `terraform-backend` groups have the required access to manage cross-project resources.