### PR TITLE
Add `gke-security-groups` Google Group for Kubernetes RBAC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Code Owners
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @coderabbitai
 * @osinfra-io/platform-google-cloud-landing-zone
 * @osinfra-sa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Code Owners
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @coderabbitai[bot]
+* @coderabbitai
 * @osinfra-io/platform-google-cloud-landing-zone
 * @osinfra-sa

--- a/.github/ISSUE_TEMPLATE/add-update-identity-group.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-identity-group.yml
@@ -63,6 +63,15 @@ body:
     validations:
       required: false
 
+  - type: checkboxes
+    id: gke-security-groups
+    attributes:
+      label: "GKE security groups:"
+      description: "Check below if this group is a GKE security groups."
+      options:
+        - label: "Add to GKE security groups"
+          required: false
+
   - type: textarea
     id: comments
     attributes:

--- a/.github/ISSUE_TEMPLATE/add-update-identity-group.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-identity-group.yml
@@ -67,9 +67,9 @@ body:
     id: gke-security-groups
     attributes:
       label: "GKE security groups:"
-      description: "Check below if this group is a GKE security groups."
+      description: "Check below if this group is a nested GKE security group."
       options:
-        - label: "Add to GKE security groups"
+        - label: "Add as a nested group to GKE security groups"
           required: false
 
   - type: textarea

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -577,7 +577,7 @@ identity_groups = {
     description  = "Security group for Kubernetes role-based access control (RBAC)"
     display_name = "Kubernetes Security Groups"
     managers     = []
-    members      = ["testing-nested-gke-security-group@osinfra.io"]
+    members      = ["gke-testing-security-group@osinfra.io"]
     owners       = []
     roles        = []
   }
@@ -693,9 +693,11 @@ identity_groups = {
     roles  = []
   }
 
-  testing-nested-gke-security-group = {
-    description  = "Testing nested group for Kubernetes role-based access control (RBAC)"
-    display_name = "Testing Nested Kubernetes Security Groups"
+  # This is an example of a nested group. This group is added as a member of the gke-security-groups group.
+
+  gke-testing-security-group = {
+    description  = "GKE security group for the testing environment"
+    display_name = "GKE Testing Security Group"
     managers     = []
     members      = []
     owners       = ["plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"]

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -511,7 +511,7 @@ identity_groups = {
     owners = [
       "brett@osinfra.io",
 
-      # These service accounts create the IAP brands in the sandbox and production environments
+      # This service account creates the IAP brand in the sandbox environment.
       # It required to be an owner of the group for the Terraform resource google_iap_brand to work.
 
       "plt-backstage-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com"
@@ -527,7 +527,7 @@ identity_groups = {
     owners = [
       "brett@osinfra.io",
 
-      # These service accounts create the IAP brands in the sandbox and production environments
+      # This service account creates the IAP brand in the production environment.
       # It required to be an owner of the group for the Terraform resource google_iap_brand to work.
 
       "plt-backstage-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
@@ -567,6 +567,22 @@ identity_groups = {
     members      = []
     owners       = ["brett@osinfra.io"]
     roles        = []
+  }
+
+  # This Google Group is required to enable Kubernetes role-based access control (RBAC)
+  # in your Google Kubernetes Engine (GKE) clusters. Add your groups as nested groups to this group.
+  # Don't add individual users as members of gke-security-groups.
+
+  gke-security-groups = {
+    description  = "Security group for Kubernetes role-based access control (RBAC)"
+    display_name = "Kubernetes Security Groups"
+
+    # The managers of this groupd should be the service accounts that create the GKE clusters and manages onboarding.
+
+    managers = []
+    members  = []
+    owners   = []
+    roles    = []
   }
 
   help = {

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -511,7 +511,7 @@ identity_groups = {
     owners = [
       "brett@osinfra.io",
 
-      # This service account creates the IAP brand in the sandbox environment.
+      # This service account creates the IAP brand in the production environment.
       # It required to be an owner of the group for the Terraform resource google_iap_brand to work.
 
       "plt-backstage-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com"
@@ -527,7 +527,7 @@ identity_groups = {
     owners = [
       "brett@osinfra.io",
 
-      # This service account creates the IAP brand in the production environment.
+      # This service account creates the IAP brand in the sandbox environment.
       # It required to be an owner of the group for the Terraform resource google_iap_brand to work.
 
       "plt-backstage-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
@@ -576,13 +576,10 @@ identity_groups = {
   gke-security-groups = {
     description  = "Security group for Kubernetes role-based access control (RBAC)"
     display_name = "Kubernetes Security Groups"
-
-    # The managers of this groupd should be the service accounts that create the GKE clusters and manages onboarding.
-
-    managers = []
-    members  = []
-    owners   = []
-    roles    = []
+    managers     = []
+    members      = ["testing-nested-gke-security-group@osinfra.io"]
+    owners       = []
+    roles        = []
   }
 
   help = {
@@ -694,6 +691,15 @@ identity_groups = {
 
     owners = ["brett@osinfra.io"]
     roles  = []
+  }
+
+  testing-nested-gke-security-group = {
+    description  = "Testing nested group for Kubernetes role-based access control (RBAC)"
+    display_name = "Testing Nested Kubernetes Security Groups"
+    managers     = []
+    members      = []
+    owners       = ["plt-lz-testing-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"]
+    roles        = []
   }
 
   social = {


### PR DESCRIPTION
Fixes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new checkbox input for "GKE security groups" in issue templates.
  - Implemented role-based access control with a new Google Group for GKE clusters.
- **Documentation**
  - Updated issue templates to improve clarity on security group additions.
- **Infrastructure**
  - Configured IAP brands across multiple environments.
  - Updated service account permissions for IAP brand management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->