### PR TITLE
Add k8s backend service accounts to registry readers manager

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
 
@@ -32,7 +32,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=false
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.174
+    rev: 3.2.255
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Links to documentation and other resources required to develop and iterate in th
 
 ### 📓 Terraform Documentation
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 #### Providers
 
 | Name | Version |
 |------|---------|
-| google | 5.39.1 |
+| google | 6.3.0 |
 
 #### Resources
 
@@ -86,4 +86,4 @@ Links to documentation and other resources required to develop and iterate in th
 | organization\_id | The organization ID to create the hierarchy under | `string` | n/a | yes |
 | organization\_monthly\_budget\_amount | The organization monthly budget amount in USD | `number` | `100` | no |
 | primary\_domain | The main domain associated with your Google Workspace account. By default, your users get a username at this domain | `string` | `"osinfra.io"` | no |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/tfvars/production.tfvars
+++ b/tfvars/production.tfvars
@@ -603,14 +603,16 @@ identity_groups = {
   platform-registry-readers = {
     description  = "Group for reading from the platform artifact registry repository"
     display_name = "Platform Registry Readers"
-    managers     = []
 
-    members = [
-      # Repository: google-kubernetes-engine
+    managers = [
+      "plt-k8s-github@ptl-lz-terraform-tf05-nonprod.iam.gserviceaccount.com",
+      "plt-k8s-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com",
+      "plt-k8s-github@ptl-lz-terraform-tf91-sb.iam.gserviceaccount.com"
     ]
 
-    owners = ["brett@osinfra.io"]
-    roles  = []
+    members = []
+    owners  = ["brett@osinfra.io"]
+    roles   = []
   }
 
   platform-registry-writers = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated pre-commit hooks to utilize the latest versions of Terraform and Checkov, enhancing functionality and reliability.
	- Incremented the Google provider version in documentation, reflecting improvements.

- **Bug Fixes**
	- Adjusted management structure for the `platform-registry-readers` group by designating specific service accounts as managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->